### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_user_session, only: [:new, :edit]
-  before_action :set_item, only: [:show, :edit, :update] #before_actionにも順番がある
+  before_action :set_item, only: [:show, :edit, :update, :destroy] #before_actionにも順番がある
   before_action :move_to_root, only: [:edit]
   
   def index
@@ -32,6 +32,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :move_to_user_session, only: [:new, :edit]
+  before_action :move_to_user_session, only: [:new, :edit, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy] #before_actionにも順番がある
-  before_action :move_to_root, only: [:edit]
+  before_action :move_to_root, only: [:edit, :destroy]
   
   def index
     @items = Item.all.order(created_at: :desc)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "/items/#{@item.id}/edit", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", "/items/#{@item.id}", method: :delete, class:"item-destroy" %>
 
     <% elsif user_signed_in? && current_user.id != @item.user_id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
# What
商品情報削除機能の実装

# Why
フリマアプリ実装にあたり、商品情報の削除機能が必要なため

# gyazoのURL
### ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://i.gyazo.com/f01f9d0aaa23c55e552f7a78a2159077.mp4
